### PR TITLE
Componentize the Ember Versions Form

### DIFF
--- a/app/components/ember-versions-form.hbs
+++ b/app/components/ember-versions-form.hbs
@@ -1,12 +1,22 @@
-<form data-test-form="Ember Versions" {{on "submit" this.submitForm}}>
+<form
+  data-test-form="Ember Versions"
+  {{on "submit" this.submitForm}}
+>
   <div class="mb-3">
     <label for="from-version">From version</label>
 
-    <select data-test-select="From Version" id="from-version" {{on "input" this.updateFromVersion}}>
+    <select
+      data-test-select="From Version"
+      id="from-version"
+      {{on "input" this.updateFromVersion}}
+    >
       {{#each this.versions as |version|}}
-      <option selected={{eq version this.fromVersion}} value={{version}}>
-        {{version}}
-      </option>
+        <option
+          selected={{eq version this.fromVersion}}
+          value={{version}}
+        >
+          {{version}}
+        </option>
       {{/each}}
     </select>
   </div>
@@ -14,11 +24,18 @@
   <div>
     <label for="to-version">To version</label>
 
-    <select data-test-select="To Version" id="to-version" {{on "input" this.updateToVersion}}>
+    <select
+      data-test-select="To Version"
+      id="to-version"
+      {{on "input" this.updateToVersion}}
+    >
       {{#each this.versions as |version|}}
-      <option selected={{eq version this.toVersion}} value={{version}}>
-        {{version}}
-      </option>
+        <option
+          selected={{eq version this.toVersion}}
+          value={{version}}
+        >
+          {{version}}
+        </option>
       {{/each}}
     </select>
   </div>

--- a/app/components/ember-versions-form.hbs
+++ b/app/components/ember-versions-form.hbs
@@ -1,0 +1,25 @@
+<form data-test-form="Ember Versions" {{on "submit" this.submitForm}}>
+  <div class="mb-3">
+    <label for="from-version">From version</label>
+
+    <select data-test-select="From Version" id="from-version" {{on "input" this.updateFromVersion}}>
+      {{#each this.versions as |version|}}
+      <option selected={{eq version this.fromVersion}} value={{version}}>
+        {{version}}
+      </option>
+      {{/each}}
+    </select>
+  </div>
+
+  <div>
+    <label for="to-version">To version</label>
+
+    <select data-test-select="To Version" id="to-version" {{on "input" this.updateToVersion}}>
+      {{#each this.versions as |version|}}
+      <option selected={{eq version this.toVersion}} value={{version}}>
+        {{version}}
+      </option>
+      {{/each}}
+    </select>
+  </div>
+</form>

--- a/app/components/ember-versions-form.js
+++ b/app/components/ember-versions-form.js
@@ -1,0 +1,33 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { VERSIONS } from '../models/versions';
+
+export default class EmberVersionsFormComponent extends Component {
+  versions = VERSIONS;
+  @tracked fromVersion = '3.15';
+  @tracked toVersion = VERSIONS[VERSIONS.length - 1];
+
+  @action submitForm(event) {
+    event.preventDefault();
+
+    const { onSubmit } = this.args;
+
+    if (onSubmit) {
+      onSubmit({
+        fromVersion: this.fromVersion,
+        toVersion: this.toVersion,
+      });
+    }
+  }
+
+  @action updateFromVersion(event) {
+    this.fromVersion = event.target.value;
+    this.submitForm(event);
+  }
+
+  @action updateToVersion(event) {
+    this.toVersion = event.target.value;
+    this.submitForm(event);
+  }
+}

--- a/tests/integration/components/ember-versions-form-test.js
+++ b/tests/integration/components/ember-versions-form-test.js
@@ -1,0 +1,84 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { fillIn, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | ember-versions-form', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('renders a form', async function (assert) {
+    await render(hbs`<EmberVersionsForm />`);
+
+    assert
+      .dom('[data-test-form="Ember Versions"]')
+      .exists('We can see the form.');
+
+    assert
+      .dom('[data-test-select="From Version"]')
+      .exists('We can see the select for From Version.');
+
+    assert
+      .dom('[data-test-select="To Version"]')
+      .exists('We can see the select for To Version.');
+  });
+
+  test('sends the updated fromVersion when we submit form after changing fromVersion', async function (assert) {
+    assert.expect(3);
+
+    this.onSubmit = ({ fromVersion, toVersion }) => {
+      assert.strictEqual(
+        fromVersion,
+        '2.17',
+        'We get the correct value for fromVersion.'
+      );
+
+      assert.strictEqual(
+        toVersion,
+        '3.21',
+        'We get the correct value for toVersion.'
+      );
+    };
+
+    await render(hbs`
+      <EmberVersionsForm
+        @onSubmit={{this.onSubmit}}
+      />
+    `);
+
+    await fillIn('[data-test-select="From Version"]', '2.17');
+
+    assert
+      .dom('[data-test-select="From Version"]')
+      .hasValue('2.17', 'The select option shows the new value.');
+  });
+
+  test('sends the updated toVersion when we submit form after changing toVersion', async function (assert) {
+    assert.expect(3);
+
+    this.onSubmit = ({ fromVersion, toVersion }) => {
+      assert.strictEqual(
+        fromVersion,
+        '3.15',
+        'We get the correct value for fromVersion.'
+      );
+
+      assert.strictEqual(
+        toVersion,
+        '3.18',
+        'We get the correct value for toVersion.'
+      );
+    };
+
+    await render(hbs`
+      <EmberVersionsForm
+        @onSubmit={{this.onSubmit}}
+      />
+    `);
+
+    await fillIn('[data-test-select="To Version"]', '3.18');
+
+    assert
+      .dom('[data-test-select="To Version"]')
+      .hasValue('3.18', 'The select option shows the new value.');
+  });
+});


### PR DESCRIPTION
## Description

I created the `<EmberVersionsForm>` component which is the first part of simplifying the `index` route template.

Closes https://github.com/ember-learn/upgrade-guide/issues/44

## TODOs
- [x] Use Ember CLI to generate a component called `<EmberVersionsForm>`, along with the backing class. 
- [x] Copy-paste the form and relevant class code from the `index` route to the component.
- [x] Rename the action `doNotSubmitForm` to `submitForm`. In addition to `event.preventDefault`, it should call `@onSubmit` (if the callback function exists) and pass the form state` fromVersion` and `toVersion` in a hash (POJO).
- [x] For now (this behavior will change in another issue), we want to call `submitForm` when the user changes the select option. Modify `updateFromVersion` and `updateToVersion` so that they will call `submitForm`.
- [x] Write rendering tests to describe how the form should behave. Please write tests to check the following:

  - Initially, the form shows 3.15 and the latest version for fromVersion and toVersion.
  - We can submit the form by changing fromVersion. In addition to asserting that we see the correct select option, assert that @onSubmit is called and receives the new values of fromVersion and toVersion.
  - We can submit the form by changing toVersion. In addition to asserting that we see the correct select option, assert that @onSubmit is called and receives the new values of fromVersion and toVersion.
