### PR TITLE
Simplify index route by cleaning up the controller and invoking the <EmberVersionsForm> component

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,4 +1,5 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { VERSIONS } from 'upgrade-guide/utils/ember-versions';
 
@@ -8,4 +9,9 @@ export default class IndexController extends Controller {
   versions = VERSIONS;
   @tracked fromVersion = '3.15';
   @tracked toVersion = VERSIONS[VERSIONS.length - 1];
+
+  @action displayChanges({ fromVersion, toVersion }) {
+    this.fromVersion = fromVersion;
+    this.toVersion = toVersion;
+  }
 }

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,5 +1,4 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { VERSIONS } from 'upgrade-guide/utils/ember-versions';
 
@@ -9,16 +8,4 @@ export default class IndexController extends Controller {
   versions = VERSIONS;
   @tracked fromVersion = '3.15';
   @tracked toVersion = VERSIONS[VERSIONS.length - 1];
-
-  @action doNotSubmitForm(event) {
-    event.preventDefault();
-  }
-
-  @action updateFromVersion(event) {
-    this.fromVersion = event.target.value;
-  }
-
-  @action updateToVersion(event) {
-    this.toVersion = event.target.value;
-  }
 }

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,48 +1,9 @@
 <section class="container">
   <h1 class="es-heading">Upgrade Guide</h1>
 
-  <form
-    data-test-form="Ember Versions"
-    {{on "submit" this.doNotSubmitForm}}
-  >
-    <div class="mb-3">
-      <label for="from-version">From version</label>
-
-      <select
-        data-test-select="From Version"
-        id="from-version"
-        {{on "input" this.updateFromVersion}}
-      >
-        {{#each this.versions as |version|}}
-          <option
-            selected={{eq version this.fromVersion}}
-            value={{version}}
-          >
-            {{version}}
-          </option>
-        {{/each}}
-      </select>
-    </div>
-
-    <div>
-      <label for="to-version">To version</label>
-
-      <select
-        data-test-select="To Version"
-        id="to-version"
-        {{on "input" this.updateToVersion}}
-      >
-        {{#each this.versions as |version|}}
-          <option
-            selected={{eq version this.toVersion}}
-            value={{version}}
-          >
-            {{version}}
-          </option>
-        {{/each}}
-      </select>
-    </div>
-  </form>
+  <EmberVersionsForm
+    @onSubmit={{displayChanges}}
+  />
 
 
   <h2>Upgrading from {{this.fromVersion}} to {{this.toVersion}}</h2>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -2,7 +2,7 @@
   <h1 class="es-heading">Upgrade Guide</h1>
 
   <EmberVersionsForm
-    @onSubmit={{displayChanges}}
+    @onSubmit={{this.displayChanges}}
   />
 
 


### PR DESCRIPTION
This is the second part of componentizing the Ember Versions form. I cleaned up the `index` controller by removing the `doNotSubmitForm`, `updateFromVersion`, and `updateToVersion` actions and then invoked the `<EmberVersionsForm>` component in the `index` route.