### PR TITLE
Create changes route

### DIFF
--- a/app/controllers/changes.js
+++ b/app/controllers/changes.js
@@ -1,0 +1,10 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { VERSIONS } from 'upgrade-guide/utils/ember-versions';
+
+export default class ChangesController extends Controller {
+  queryParams = ['fromVersion', 'toVersion'];
+
+  @tracked fromVersion = '3.15';
+  @tracked toVersion = VERSIONS[VERSIONS.length - 1];
+}

--- a/app/router.js
+++ b/app/router.js
@@ -6,4 +6,6 @@ export default class Router extends EmberRouter {
   rootURL = config.rootURL;
 }
 
-Router.map(function () {});
+Router.map(function () {
+  this.route('changes');
+});

--- a/app/routes/changes.js
+++ b/app/routes/changes.js
@@ -1,4 +1,11 @@
 import Route from '@ember/routing/route';
-
+import { hash } from 'rsvp';
 export default class ChangesRoute extends Route {
+  model() {
+    return hash({
+      emberJSChanges: this.store.findAll('ember-js-change'),
+      emberCLIChanges: this.store.findAll('ember-cli-change'),
+      emberDataChanges: this.store.findAll('ember-data-change'),
+    });
+  }
 }

--- a/app/routes/changes.js
+++ b/app/routes/changes.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default class ChangesRoute extends Route {
+}

--- a/app/templates/changes.hbs
+++ b/app/templates/changes.hbs
@@ -29,3 +29,7 @@
     @toVersion={{this.toVersion}}
   />
 </div>
+
+{{#link-to "index" data-test-link="Return to Homepage"}}
+  Return to Homepage
+{{/link-to}}

--- a/app/templates/changes.hbs
+++ b/app/templates/changes.hbs
@@ -1,35 +1,37 @@
-<h1>Upgrading from {{this.fromVersion}} to {{this.toVersion}}</h1>
-<CliUpdateCommands
-  @toVersion={{this.toVersion}}
-/>
-
-<div data-test-package="Ember.js">
-  <h2>Ember.js</h2>
-  <ListFeaturesDeprecations
-    @datum={{@model.emberJSChanges}}
-    @fromVersion={{this.fromVersion}}
+<section class="container">
+  <h1>Upgrading from {{this.fromVersion}} to {{this.toVersion}}</h1>
+  <CliUpdateCommands
     @toVersion={{this.toVersion}}
   />
-</div>
 
-<div data-test-package="Ember Data">
-  <h2>Ember Data</h2>
-  <ListFeaturesDeprecations
-    @datum={{@model.emberDataChanges}}
-    @fromVersion={{this.fromVersion}}
-    @toVersion={{this.toVersion}}
-  />
-</div>
+  <div data-test-package="Ember.js">
+    <h2>Ember.js</h2>
+    <ListFeaturesDeprecations
+      @datum={{@model.emberJSChanges}}
+      @fromVersion={{this.fromVersion}}
+      @toVersion={{this.toVersion}}
+    />
+  </div>
 
-<div data-test-package="Ember CLI">
-  <h2>Ember CLI</h2>
-  <ListFeaturesDeprecations
-    @datum={{@model.emberCLIChanges}}
-    @fromVersion={{this.fromVersion}}
-    @toVersion={{this.toVersion}}
-  />
-</div>
+  <div data-test-package="Ember Data">
+    <h2>Ember Data</h2>
+    <ListFeaturesDeprecations
+      @datum={{@model.emberDataChanges}}
+      @fromVersion={{this.fromVersion}}
+      @toVersion={{this.toVersion}}
+    />
+  </div>
 
-{{#link-to "index" data-test-link="Return to Homepage"}}
-  Return to Homepage
-{{/link-to}}
+  <div data-test-package="Ember CLI">
+    <h2>Ember CLI</h2>
+    <ListFeaturesDeprecations
+      @datum={{@model.emberCLIChanges}}
+      @fromVersion={{this.fromVersion}}
+      @toVersion={{this.toVersion}}
+    />
+  </div>
+
+  {{#link-to "index" data-test-link="Return to Homepage"}}
+    Return to Homepage
+  {{/link-to}}
+</section>

--- a/app/templates/changes.hbs
+++ b/app/templates/changes.hbs
@@ -31,7 +31,10 @@
     />
   </div>
 
-  {{#link-to "index" data-test-link="Return to Homepage"}}
+  <LinkTo 
+    @route="index" 
+    data-test-link="Return to Homepage"
+  >
     Return to Homepage
-  {{/link-to}}
+  </LinkTo>
 </section>

--- a/app/templates/changes.hbs
+++ b/app/templates/changes.hbs
@@ -1,0 +1,31 @@
+<h1>Upgrading from {{this.fromVersion}} to {{this.toVersion}}</h1>
+<CliUpdateCommands
+  @toVersion={{this.toVersion}}
+/>
+
+<div data-test-package="Ember.js">
+  <h2>Ember.js</h2>
+  <ListFeaturesDeprecations
+    @datum={{@model.emberJSChanges}}
+    @fromVersion={{this.fromVersion}}
+    @toVersion={{this.toVersion}}
+  />
+</div>
+
+<div data-test-package="Ember Data">
+  <h2>Ember Data</h2>
+  <ListFeaturesDeprecations
+    @datum={{@model.emberDataChanges}}
+    @fromVersion={{this.fromVersion}}
+    @toVersion={{this.toVersion}}
+  />
+</div>
+
+<div data-test-package="Ember CLI">
+  <h2>Ember CLI</h2>
+  <ListFeaturesDeprecations
+    @datum={{@model.emberCLIChanges}}
+    @fromVersion={{this.fromVersion}}
+    @toVersion={{this.toVersion}}
+  />
+</div>

--- a/tests/acceptance/changes-test.js
+++ b/tests/acceptance/changes-test.js
@@ -1,0 +1,154 @@
+import { module, test } from 'qunit';
+import { click, currentURL, findAll, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+module('Acceptance | changes', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('When we visit the changes route without query parameters, we see the features and deprecations that occurred since version 3.15', async function (assert) {
+    await visit('/changes');
+
+    // Check new features in Ember.js
+    const newFeaturesInEmberJS = findAll(
+      '[data-test-package="Ember.js"] [data-test-feature]'
+    );
+
+    assert.strictEqual(
+      newFeaturesInEmberJS.length,
+      1,
+      'We see 1 new feature that occurred in Ember.js since version 3.15'
+    );
+
+    // Check deprecations in Ember.js
+    const deprecationsInEmberJS = findAll(
+      '[data-test-package="Ember.js"] [data-test-deprecation]'
+    );
+
+    assert.strictEqual(
+      deprecationsInEmberJS.length,
+      2,
+      'We see 2 deprecations that occurred in Ember.js since version 3.15'
+    );
+
+    // Check new features in Ember Data
+    const newFeaturesInEmberData = findAll(
+      '[data-test-package="Ember Data"] [data-test-feature]'
+    );
+
+    assert.strictEqual(
+      newFeaturesInEmberData.length,
+      1,
+      'We see 1 new feature that occurred in Ember Data since version 3.15'
+    );
+
+    // Check deprecations in Ember Data
+    const deprecationsInEmberData = findAll(
+      '[data-test-package="Ember Data"] [data-test-deprecation]'
+    );
+
+    assert.strictEqual(
+      deprecationsInEmberData.length,
+      0,
+      'We see 0 deprecations that occurred in Ember Data since version 3.15'
+    );
+
+    // Check new features in Ember CLI
+    const newFeaturesInEmberCLI = findAll(
+      '[data-test-package="Ember CLI"] [data-test-feature]'
+    );
+
+    assert.strictEqual(
+      newFeaturesInEmberCLI.length,
+      3,
+      'We see 3 new features that occurred in Ember CLI since version 3.15'
+    );
+
+    // Check deprecations in Ember CLI
+    const deprecationsInEmberCLI = findAll(
+      '[data-test-package="Ember CLI"] [data-test-deprecation]'
+    );
+
+    assert.strictEqual(
+      deprecationsInEmberCLI.length,
+      2,
+      'We see 2 deprecations that occurred in Ember CLI since version 3.15'
+    );
+  });
+
+  test('When we visit the changes route with query parameters, we see the features and deprecations that occurred between fromVersion and toVersion', async function (assert) {
+    await visit('/changes?fromVersion=2.17&toVersion=3.3');
+
+    // Check new features in Ember.js
+    const newFeaturesInEmberJS = findAll(
+      '[data-test-package="Ember.js"] [data-test-feature]'
+    );
+
+    assert.strictEqual(
+      newFeaturesInEmberJS.length,
+      8,
+      'We see 8 new features that occurred in Ember.js between 2.17 and 3.3'
+    );
+
+    // Check deprecations in Ember.js
+    const deprecationsInEmberJS = findAll(
+      '[data-test-package="Ember.js"] [data-test-deprecation]'
+    );
+
+    assert.strictEqual(
+      deprecationsInEmberJS.length,
+      9,
+      'We see 9 deprecations that occurred in Ember.js between 2.17 and 3.3'
+    );
+
+    // Check new features in Ember Data
+    const newFeaturesInEmberData = findAll(
+      '[data-test-package="Ember Data"] [data-test-feature]'
+    );
+
+    assert.strictEqual(
+      newFeaturesInEmberData.length,
+      5,
+      'We see 5 new features that occurred in Ember Data between 2.17 and 3.3'
+    );
+
+    // Check deprecations in Ember Data
+    const deprecationsInEmberData = findAll(
+      '[data-test-package="Ember Data"] [data-test-deprecation]'
+    );
+
+    assert.strictEqual(
+      deprecationsInEmberData.length,
+      1,
+      'We see 1 deprecation that occurred in Ember Data between 2.17 and 3.3'
+    );
+
+    // Check new features in Ember CLI
+    const newFeaturesInEmberCLI = findAll(
+      '[data-test-package="Ember CLI"] [data-test-feature]'
+    );
+
+    assert.strictEqual(
+      newFeaturesInEmberCLI.length,
+      2,
+      'We see 2 new features that occurred in Ember CLI between 2.17 and 3.3'
+    );
+
+    // Check deprecations in Ember CLI
+    const deprecationsInEmberCLI = findAll(
+      '[data-test-package="Ember CLI"] [data-test-deprecation]'
+    );
+
+    assert.strictEqual(
+      deprecationsInEmberCLI.length,
+      1,
+      'We see 1 deprecation that occurred in Ember CLI between 2.17 and 3.3'
+    );
+  });
+
+  test('When we click the Return to Homepage button, we are redirected to the index route', async function (assert) {
+    await visit('/changes');
+    await click('[data-test-link="Return to Homepage"]');
+
+    assert.strictEqual(currentURL(), '/', 'We see the correct URL.');
+  });
+});

--- a/tests/unit/controllers/changes-test.js
+++ b/tests/unit/controllers/changes-test.js
@@ -4,7 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Controller | changes', function (hooks) {
   setupTest(hooks);
 
-  // TODO: Replace this with your real tests.
   test('it exists', function (assert) {
     let controller = this.owner.lookup('controller:changes');
     assert.ok(controller);

--- a/tests/unit/controllers/changes-test.js
+++ b/tests/unit/controllers/changes-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | changes', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:changes');
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/routes/changes-test.js
+++ b/tests/unit/routes/changes-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | changes', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:changes');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
This is the first part of separating the form and search results. We're creating a new route called the `changes` route. This shows features and deprecations that were added between fromVersion and toVersion. It also shows a link to go back to the index route.

Closes https://github.com/ember-learn/upgrade-guide/issues/48