### PR TITLE
Simplify list component

### DIFF
--- a/app/components/list-features-deprecations.hbs
+++ b/app/components/list-features-deprecations.hbs
@@ -1,7 +1,7 @@
 <h3>New features</h3>
 <h4 class="mb-1">Count: {{this.features.length}}</h4>
 
-{{#if this.features.length}}
+{{#if this.features}}
   <ul>
     {{#each this.features as |feature|}}
       <li data-test-feature>
@@ -25,7 +25,7 @@
 <h3>Deprecations</h3>
 <h4 class="mb-1">Count: {{this.deprecations.length}}</h4>
 
-{{#if this.deprecations.length}}
+{{#if this.deprecations}}
   <ul>
     {{#each this.deprecations as |deprecation|}}
       <li data-test-deprecation>

--- a/app/components/list-features-deprecations.hbs
+++ b/app/components/list-features-deprecations.hbs
@@ -1,7 +1,7 @@
 <h3>New features</h3>
-<h4 class="mb-1">Count: {{this.countOfFeatureChanges}}</h4>
+<h4 class="mb-1">Count: {{this.features.length}}</h4>
 
-{{#if this.countOfFeatureChanges}}
+{{#if this.features.length}}
   <ul>
     {{#each this.features as |feature|}}
       <li data-test-feature>
@@ -23,9 +23,9 @@
 {{/if}}
 
 <h3>Deprecations</h3>
-<h4 class="mb-1">Count: {{this.countOfDeprecationChanges}}</h4>
+<h4 class="mb-1">Count: {{this.deprecations.length}}</h4>
 
-{{#if this.countOfDeprecationChanges}}
+{{#if this.deprecations.length}}
   <ul>
     {{#each this.deprecations as |deprecation|}}
       <li data-test-deprecation>

--- a/app/components/list-features-deprecations.hbs
+++ b/app/components/list-features-deprecations.hbs
@@ -3,23 +3,19 @@
 
 {{#if this.countOfFeatureChanges}}
   <ul>
-    {{#each this.model as |model|}}
-      {{#each model.changes as |change|}}
-        {{#if change.feature}}
-          <li data-test-feature>
-            <span data-test-field="Title">{{change.title}}</span>
-            <a
-              data-test-field="Version"
-              href={{change.link}}
-              rel="noopener noreferrer"
-              target="_blank"
-              title="Check version {{model.version}} link for more info"
-            >
-              ({{model.version}})
-            </a>
-          </li>
-        {{/if}}
-      {{/each}}
+    {{#each this.features as |feature|}}
+      <li data-test-feature>
+        <span data-test-field="Title">{{feature.title}}</span>
+        <a
+          data-test-field="Version"
+          href={{feature.link}}
+          rel="noopener noreferrer"
+          target="_blank"
+          title="Check version {{feature.version}} link for more info"
+        >
+          ({{feature.version}})
+        </a>
+      </li>
     {{/each}}
   </ul>
 {{else}}
@@ -31,23 +27,19 @@
 
 {{#if this.countOfDeprecationChanges}}
   <ul>
-    {{#each this.model as |model|}}
-      {{#each model.changes as |change|}}
-        {{#if change.deprecation}}
-          <li data-test-deprecation>
-            <span data-test-field="Title">{{change.title}}</span>
-            <a
-              data-test-field="Version"
-              href={{change.link}}
-              rel="noopener noreferrer"
-              target="_blank"
-              title="Check version {{model.version}} link for more info"
-            >
-              ({{model.version}})
-            </a>
-          </li>
-        {{/if}}
-      {{/each}}
+    {{#each this.deprecations as |deprecation|}}
+      <li data-test-deprecation>
+        <span data-test-field="Title">{{deprecation.title}}</span>
+        <a
+          data-test-field="Version"
+          href={{deprecation.link}}
+          rel="noopener noreferrer"
+          target="_blank"
+          title="Check version {{deprecation.version}} link for more info"
+        >
+          ({{deprecation.version}})
+        </a>
+      </li>
     {{/each}}
   </ul>
 {{else}}

--- a/app/components/list-features-deprecations.js
+++ b/app/components/list-features-deprecations.js
@@ -26,4 +26,24 @@ export default class ListFeaturesDeprecationsComponent extends Component {
       return total + item.deprecationsCount;
     }, 0);
   }
+
+  @computed('relevantChangeLogs')
+  get features() {
+    return this.relevantChangeLogs.reduce((features, changeLog) => {
+      const filteredChanges = changeLog.changes.reduce(
+        (accumulator, currentChange) => {
+          if (currentChange.feature) {
+            accumulator.push({
+              title: currentChange.title,
+              link: currentChange.link,
+              version: changeLog.version,
+            });
+          }
+          return accumulator;
+        },
+        []
+      );
+      return features.concat(filteredChanges);
+    }, []);
+  }
 }

--- a/app/components/list-features-deprecations.js
+++ b/app/components/list-features-deprecations.js
@@ -14,20 +14,6 @@ export default class ListFeaturesDeprecationsComponent extends Component {
   }
 
   @computed('relevantChangeLogs')
-  get countOfFeatureChanges() {
-    return this.relevantChangeLogs.reduce((total = 0, item) => {
-      return total + item.featuresCount;
-    }, 0);
-  }
-
-  @computed('relevantChangeLogs')
-  get countOfDeprecationChanges() {
-    return this.relevantChangeLogs.reduce((total = 0, item) => {
-      return total + item.deprecationsCount;
-    }, 0);
-  }
-
-  @computed('relevantChangeLogs')
   get features() {
     return this.relevantChangeLogs.reduce((features, changeLog) => {
       const filteredChanges = changeLog.changes.reduce(

--- a/app/components/list-features-deprecations.js
+++ b/app/components/list-features-deprecations.js
@@ -3,9 +3,9 @@ import { computed } from '@ember/object';
 import { compare } from 'compare-versions';
 
 export default class ListFeaturesDeprecationsComponent extends Component {
-  @computed('args.{datum,fromVersion,toVersion}')
+  @computed('args.{allChangeLogs,fromVersion,toVersion}')
   get model() {
-    return this.args.datum.filter((model) => {
+    return this.args.allChangeLogs.filter((model) => {
       return (
         compare(this.args.toVersion, model.version, '>=') &&
         compare(this.args.fromVersion, model.version, '<')

--- a/app/components/list-features-deprecations.js
+++ b/app/components/list-features-deprecations.js
@@ -6,7 +6,13 @@ import { filterBy } from '@ember/object/computed';
 export default class ListFeaturesDeprecationsComponent extends Component {
   @computed('args.{allChangeLogs,fromVersion,toVersion}')
   get relevantChangeLogs() {
-    return this.args.allChangeLogs.filter((changeLog) => {
+    const { allChangeLogs } = this.args;
+
+    if (!allChangeLogs) {
+      return [];
+    }
+
+    return allChangeLogs.filter((changeLog) => {
       return (
         compare(this.args.toVersion, changeLog.version, '>=') &&
         compare(this.args.fromVersion, changeLog.version, '<')

--- a/app/components/list-features-deprecations.js
+++ b/app/components/list-features-deprecations.js
@@ -46,4 +46,24 @@ export default class ListFeaturesDeprecationsComponent extends Component {
       return features.concat(filteredChanges);
     }, []);
   }
+
+  @computed('relevantChangeLogs')
+  get deprecations() {
+    return this.relevantChangeLogs.reduce((deprecations, changeLog) => {
+      const filteredChanges = changeLog.changes.reduce(
+        (accumulator, currentChange) => {
+          if (currentChange.deprecation) {
+            accumulator.push({
+              title: currentChange.title,
+              link: currentChange.link,
+              version: changeLog.version,
+            });
+          }
+          return accumulator;
+        },
+        []
+      );
+      return deprecations.concat(filteredChanges);
+    }, []);
+  }
 }

--- a/app/components/list-features-deprecations.js
+++ b/app/components/list-features-deprecations.js
@@ -4,25 +4,25 @@ import { compare } from 'compare-versions';
 
 export default class ListFeaturesDeprecationsComponent extends Component {
   @computed('args.{allChangeLogs,fromVersion,toVersion}')
-  get model() {
-    return this.args.allChangeLogs.filter((model) => {
+  get relevantChangeLogs() {
+    return this.args.allChangeLogs.filter((changeLog) => {
       return (
-        compare(this.args.toVersion, model.version, '>=') &&
-        compare(this.args.fromVersion, model.version, '<')
+        compare(this.args.toVersion, changeLog.version, '>=') &&
+        compare(this.args.fromVersion, changeLog.version, '<')
       );
     });
   }
 
-  @computed('model')
+  @computed('relevantChangeLogs')
   get countOfFeatureChanges() {
-    return this.model.reduce((total = 0, item) => {
+    return this.relevantChangeLogs.reduce((total = 0, item) => {
       return total + item.featuresCount;
     }, 0);
   }
 
-  @computed('model')
+  @computed('relevantChangeLogs')
   get countOfDeprecationChanges() {
-    return this.model.reduce((total = 0, item) => {
+    return this.relevantChangeLogs.reduce((total = 0, item) => {
       return total + item.deprecationsCount;
     }, 0);
   }

--- a/app/components/list-features-deprecations.js
+++ b/app/components/list-features-deprecations.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { computed } from '@ember/object';
 import { compare } from 'compare-versions';
+import { filterBy } from '@ember/object/computed';
 
 export default class ListFeaturesDeprecationsComponent extends Component {
   @computed('args.{allChangeLogs,fromVersion,toVersion}')
@@ -14,42 +15,20 @@ export default class ListFeaturesDeprecationsComponent extends Component {
   }
 
   @computed('relevantChangeLogs')
-  get features() {
-    return this.relevantChangeLogs.reduce((features, changeLog) => {
-      const filteredChanges = changeLog.changes.reduce(
-        (accumulator, currentChange) => {
-          if (currentChange.feature) {
-            accumulator.push({
-              title: currentChange.title,
-              link: currentChange.link,
-              version: changeLog.version,
-            });
-          }
-          return accumulator;
-        },
-        []
-      );
-      return features.concat(filteredChanges);
-    }, []);
+  get flattenedChangeLogs() {
+    return this.relevantChangeLogs.flatMap((changeLog) => {
+      return changeLog.changes.map((currentChange) => {
+        return {
+          version: changeLog.version,
+          ...currentChange,
+        };
+      });
+    });
   }
 
-  @computed('relevantChangeLogs')
-  get deprecations() {
-    return this.relevantChangeLogs.reduce((deprecations, changeLog) => {
-      const filteredChanges = changeLog.changes.reduce(
-        (accumulator, currentChange) => {
-          if (currentChange.deprecation) {
-            accumulator.push({
-              title: currentChange.title,
-              link: currentChange.link,
-              version: changeLog.version,
-            });
-          }
-          return accumulator;
-        },
-        []
-      );
-      return deprecations.concat(filteredChanges);
-    }, []);
-  }
+  @filterBy('flattenedChangeLogs', 'deprecation')
+  deprecations;
+
+  @filterBy('flattenedChangeLogs', 'feature')
+  features;
 }

--- a/app/models/private/-common.js
+++ b/app/models/private/-common.js
@@ -11,12 +11,4 @@ export default class CommonModel extends Model {
   get deprecations() {
     return (this.changes || []).filterBy('deprecation');
   }
-
-  get featuresCount() {
-    return this.features.length;
-  }
-
-  get deprecationsCount() {
-    return this.deprecations.length;
-  }
 }

--- a/app/templates/changes.hbs
+++ b/app/templates/changes.hbs
@@ -7,7 +7,7 @@
   <div data-test-package="Ember.js">
     <h2>Ember.js</h2>
     <ListFeaturesDeprecations
-      @datum={{@model.emberJSChanges}}
+      @allChangeLogs={{@model.emberJSChanges}}
       @fromVersion={{this.fromVersion}}
       @toVersion={{this.toVersion}}
     />
@@ -16,7 +16,7 @@
   <div data-test-package="Ember Data">
     <h2>Ember Data</h2>
     <ListFeaturesDeprecations
-      @datum={{@model.emberDataChanges}}
+      @allChangeLogs={{@model.emberDataChanges}}
       @fromVersion={{this.fromVersion}}
       @toVersion={{this.toVersion}}
     />
@@ -25,7 +25,7 @@
   <div data-test-package="Ember CLI">
     <h2>Ember CLI</h2>
     <ListFeaturesDeprecations
-      @datum={{@model.emberCLIChanges}}
+      @allChangeLogs={{@model.emberCLIChanges}}
       @fromVersion={{this.fromVersion}}
       @toVersion={{this.toVersion}}
     />

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -14,7 +14,7 @@
   <div data-test-package="Ember.js">
     <h2>Ember.js</h2>
     <ListFeaturesDeprecations
-      @datum={{@model.emberJSChanges}}
+      @allChangeLogs={{@model.emberJSChanges}}
       @fromVersion={{this.fromVersion}}
       @toVersion={{this.toVersion}}
     />
@@ -23,7 +23,7 @@
   <div data-test-package="Ember Data">
     <h2>Ember Data</h2>
     <ListFeaturesDeprecations
-      @datum={{@model.emberDataChanges}}
+      @allChangeLogs={{@model.emberDataChanges}}
       @fromVersion={{this.fromVersion}}
       @toVersion={{this.toVersion}}
     />
@@ -32,7 +32,7 @@
   <div data-test-package="Ember CLI">
     <h2>Ember CLI</h2>
     <ListFeaturesDeprecations
-      @datum={{@model.emberCLIChanges}}
+      @allChangeLogs={{@model.emberCLIChanges}}
       @fromVersion={{this.fromVersion}}
       @toVersion={{this.toVersion}}
     />

--- a/tests/integration/components/list-features-deprecations-test.js
+++ b/tests/integration/components/list-features-deprecations-test.js
@@ -26,14 +26,10 @@ module('Integration | Component | list-features-deprecations', function (
             title: 'Deprecation #2',
           },
         ],
-        featuresCount: 1,
-        deprecationsCount: 2,
       },
       {
         version: '3.0',
         changes: [],
-        featuresCount: 0,
-        deprecationsCount: 0,
       },
       {
         version: '3.1',
@@ -51,8 +47,6 @@ module('Integration | Component | list-features-deprecations', function (
             title: 'Deprecation #1',
           },
         ],
-        featuresCount: 2,
-        deprecationsCount: 1,
       },
       {
         version: '3.2',
@@ -62,8 +56,6 @@ module('Integration | Component | list-features-deprecations', function (
             title: 'Feature #1',
           },
         ],
-        featuresCount: 1,
-        deprecationsCount: 0,
       },
       {
         version: '3.3',
@@ -73,8 +65,6 @@ module('Integration | Component | list-features-deprecations', function (
             title: 'Deprecation #1',
           },
         ],
-        featuresCount: 0,
-        deprecationsCount: 1,
       },
     ];
   });

--- a/tests/integration/components/list-features-deprecations-test.js
+++ b/tests/integration/components/list-features-deprecations-test.js
@@ -9,7 +9,7 @@ module('Integration | Component | list-features-deprecations', function (
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    this.datum = [
+    this.allChangeLogs = [
       {
         version: '2.18',
         changes: [
@@ -86,7 +86,7 @@ module('Integration | Component | list-features-deprecations', function (
 
     await render(hbs`
       <ListFeaturesDeprecations
-        @datum={{this.datum}}
+        @allChangeLogs={{this.allChangeLogs}}
         @fromVersion={{this.fromVersion}}
         @toVersion={{this.toVersion}}
       />
@@ -174,7 +174,7 @@ module('Integration | Component | list-features-deprecations', function (
 
     await render(hbs`
       <ListFeaturesDeprecations
-        @datum={{this.datum}}
+        @allChangeLogs={{this.allChangeLogs}}
         @fromVersion={{this.fromVersion}}
         @toVersion={{this.toVersion}}
       />
@@ -220,7 +220,7 @@ module('Integration | Component | list-features-deprecations', function (
 
     await render(hbs`
       <ListFeaturesDeprecations
-        @datum={{this.datum}}
+        @allChangeLogs={{this.allChangeLogs}}
         @fromVersion={{this.fromVersion}}
         @toVersion={{this.toVersion}}
       />
@@ -294,7 +294,7 @@ module('Integration | Component | list-features-deprecations', function (
 
     await render(hbs`
       <ListFeaturesDeprecations
-        @datum={{this.datum}}
+        @allChangeLogs={{this.allChangeLogs}}
         @fromVersion={{this.fromVersion}}
         @toVersion={{this.toVersion}}
       />


### PR DESCRIPTION
This PR addresses https://github.com/ember-learn/upgrade-guide/issues/47.
It simplifies the list of deprecations and features by:
- giving arguments and getters more explicit names
- refactoring feature and deprecation getters to use a shared `flattenedChangeLogs`
- cleaning up the template to use these new names and getters