### PR TITLE
Restored caching

### DIFF
--- a/app/components/list-features-deprecations.js
+++ b/app/components/list-features-deprecations.js
@@ -1,13 +1,10 @@
 import Component from '@glimmer/component';
+import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
 import { compare } from 'compare-versions';
 
 export default class ListFeaturesDeprecationsComponent extends Component {
-  get relevantChangeLogs() {
-    const { allChangeLogs } = this.args;
-
-    if (!allChangeLogs) {
-      return [];
-    }
+  #relevantChangeLogs = createCache(() => {
+    const allChangeLogs = this.args.allChangeLogs ?? [];
 
     return allChangeLogs.filter((changeLog) => {
       return (
@@ -15,9 +12,13 @@ export default class ListFeaturesDeprecationsComponent extends Component {
         compare(this.args.fromVersion, changeLog.version, '<')
       );
     });
+  });
+
+  get relevantChangeLogs() {
+    return getValue(this.#relevantChangeLogs);
   }
 
-  get flattenedChangeLogs() {
+  #flattenedChangeLogs = createCache(() => {
     return this.relevantChangeLogs.flatMap((changeLog) => {
       return changeLog.changes.map((currentChange) => {
         return {
@@ -26,6 +27,10 @@ export default class ListFeaturesDeprecationsComponent extends Component {
         };
       });
     });
+  });
+
+  get flattenedChangeLogs() {
+    return getValue(this.#flattenedChangeLogs);
   }
 
   get deprecations() {


### PR DESCRIPTION
## Description

In #62, after upgrading `eslint-plugin-ember` to the latest, I encountered lint error messages that warned me not to use `@computed` and `@filterBy` decorators in native class components. I temporarily fixed these errors by opting out of caching.

Since Ember 3.22, we can use the cache API (i.e. `createCache()` and `getValue()`). In this pull request, I restored caching using this API.