### PR TITLE
Recorded features and deprecations for Ember v3.25 release

### DIFF
--- a/app/utils/ember-versions.js
+++ b/app/utils/ember-versions.js
@@ -78,4 +78,5 @@ export const VERSIONS = Object.freeze([
   '3.22',
   '3.23',
   '3.24',
+  '3.25',
 ]);

--- a/source/ember-cli-changes/3.25.md
+++ b/source/ember-cli-changes/3.25.md
@@ -1,0 +1,4 @@
+---
+version: "3.25"
+changes:
+---

--- a/source/ember-data-changes/3.25.md
+++ b/source/ember-data-changes/3.25.md
@@ -1,0 +1,4 @@
+---
+version: "3.25"
+changes:
+---

--- a/source/ember-js-changes/3.25.md
+++ b/source/ember-js-changes/3.25.md
@@ -1,0 +1,12 @@
+---
+version: "3.25"
+changes:
+  -
+    feature: true
+    title: "Template strict mode"
+    link: "https://blog.emberjs.com/ember-3-25-released"
+  -
+    feature: true
+    title: "Named blocks"
+    link: "https://blog.emberjs.com/ember-3-25-released"
+---

--- a/tests/acceptance/changes-test.js
+++ b/tests/acceptance/changes-test.js
@@ -15,8 +15,8 @@ module('Acceptance | changes', function (hooks) {
 
     assert.strictEqual(
       newFeaturesInEmberJS.length,
-      9,
-      'We see 9 new features that occurred in Ember.js since version 3.15'
+      11,
+      'We see 11 new features that occurred in Ember.js since version 3.15'
     );
 
     // Check deprecations in Ember.js


### PR DESCRIPTION
## Description

I summarized features and deprecations for Ember v3.25 released based on what was published in the Ember Blog.

https://blog.emberjs.com/ember-3-25-released