### PR TITLE
Update Upgrade-guide to give info up to 4.12

### DIFF
--- a/app/utils/ember-versions.js
+++ b/app/utils/ember-versions.js
@@ -86,4 +86,5 @@ export const VERSIONS = Object.freeze([
   '4.1',
   '4.2',
   '4.3',
+  '4.4',
 ]);

--- a/app/utils/ember-versions.js
+++ b/app/utils/ember-versions.js
@@ -92,4 +92,5 @@ export const VERSIONS = Object.freeze([
   '4.7',
   '4.8',
   '4.9',
+  '4.10',
 ]);

--- a/app/utils/ember-versions.js
+++ b/app/utils/ember-versions.js
@@ -85,4 +85,5 @@ export const VERSIONS = Object.freeze([
   '4.0',
   '4.1',
   '4.2',
+  '4.3',
 ]);

--- a/app/utils/ember-versions.js
+++ b/app/utils/ember-versions.js
@@ -88,4 +88,5 @@ export const VERSIONS = Object.freeze([
   '4.3',
   '4.4',
   '4.5',
+  '4.6',
 ]);

--- a/app/utils/ember-versions.js
+++ b/app/utils/ember-versions.js
@@ -90,4 +90,5 @@ export const VERSIONS = Object.freeze([
   '4.5',
   '4.6',
   '4.7',
+  '4.8',
 ]);

--- a/app/utils/ember-versions.js
+++ b/app/utils/ember-versions.js
@@ -94,4 +94,5 @@ export const VERSIONS = Object.freeze([
   '4.9',
   '4.10',
   '4.11',
+  '4.12',
 ]);

--- a/app/utils/ember-versions.js
+++ b/app/utils/ember-versions.js
@@ -89,4 +89,5 @@ export const VERSIONS = Object.freeze([
   '4.4',
   '4.5',
   '4.6',
+  '4.7',
 ]);

--- a/app/utils/ember-versions.js
+++ b/app/utils/ember-versions.js
@@ -93,4 +93,5 @@ export const VERSIONS = Object.freeze([
   '4.8',
   '4.9',
   '4.10',
+  '4.11',
 ]);

--- a/app/utils/ember-versions.js
+++ b/app/utils/ember-versions.js
@@ -91,4 +91,5 @@ export const VERSIONS = Object.freeze([
   '4.6',
   '4.7',
   '4.8',
+  '4.9',
 ]);

--- a/app/utils/ember-versions.js
+++ b/app/utils/ember-versions.js
@@ -87,4 +87,5 @@ export const VERSIONS = Object.freeze([
   '4.2',
   '4.3',
   '4.4',
+  '4.5',
 ]);

--- a/source/ember-cli-changes/4.10.md
+++ b/source/ember-cli-changes/4.10.md
@@ -1,0 +1,24 @@
+---
+version: "4.10"
+changes:
+  -
+    feature: true
+    title: "Make addAddonsToProject support creating a new project with custom target directory"
+    link: "https://blog.emberjs.com/ember-released-4-10"
+  -
+    feature: true
+    title: "Conditionally apply ESLint parser options in app and addon blueprints"
+    link: "https://blog.emberjs.com/ember-released-4-10"
+  -
+    feature: true
+    title: "Replace eslint-plugin-node with eslint-plugin-n in blueprints"
+    link: "https://blog.emberjs.com/ember-released-4-10"
+  -
+    feature: true
+    title: "Update Prettier config in blueprints to only use single quotes for .js and .ts files"
+    link: "https://blog.emberjs.com/ember-released-4-10"
+  -
+    feature: true
+    title: "Add @ember/string as a dependency of projects"
+    link: "https://blog.emberjs.com/ember-released-4-10"
+---

--- a/source/ember-cli-changes/4.11.md
+++ b/source/ember-cli-changes/4.11.md
@@ -1,0 +1,4 @@
+---
+version: "4.11"
+changes:
+---

--- a/source/ember-cli-changes/4.12.md
+++ b/source/ember-cli-changes/4.12.md
@@ -1,0 +1,48 @@
+---
+version: "4.12"
+changes:
+  -
+    feature: true
+    title: "Add Stylelint setup to app and addon blueprints"
+    link: "https://blog.emberjs.com/ember-released-4-12"
+  -
+    feature: true
+    title: "Update ESLint to v8 in app and addon blueprints"
+    link: "https://blog.emberjs.com/ember-released-4-10"
+  -
+    feature: true
+    title: " Exclude ember-cli-terser when generating apps using the --embroider option"
+    link: "https://blog.emberjs.com/ember-released-4-12"
+  -
+    feature: true
+    title: "Exclude ember-cli-sri when generating apps using the --embroider option"
+    link: "https://blog.emberjs.com/ember-released-4-12"
+  -
+    feature: true
+    title: "Remove NPM version checking"
+    link: "https://blog.emberjs.com/ember-released-4-12"
+  -
+    feature: true
+    title: "Remove app.import comment in app blueprint"
+    link: "https://blog.emberjs.com/ember-released-4-12"
+  -
+    feature: true
+    title: "Lazy require heavier packages"
+    link: "https://blog.emberjs.com/ember-released-4-12"
+  -
+    feature: true
+    title: "Don't delete the newly-generated app directory when an error occurs"
+    link: "https://blog.emberjs.com/ember-released-4-12"
+  -
+    feature: true
+    title: "Update ember-welcome-page to v7 in app blueprint"
+    link: "https://blog.emberjs.com/ember-released-4-12"
+  -
+    feature: true
+    title: "Update ESLint parser ecmaVersion to latest in app blueprint"
+    link: "https://blog.emberjs.com/ember-released-4-12"
+  -
+    feature: true
+    title: "Add v4.8 LTS to addon blueprint - Remove v3.28 LTS and ember-classic scenario"
+    link: "https://blog.emberjs.com/ember-released-4-12"
+---

--- a/source/ember-cli-changes/4.3.md
+++ b/source/ember-cli-changes/4.3.md
@@ -1,0 +1,16 @@
+---
+version: "4.3"
+changes:
+  -
+    feature: true
+    title: "Customisation of setupTest* functions"
+    link: "https://blog.emberjs.com/ember-released-4-3"
+  -
+    feature: true
+    title: "Add support for specifying a path for the ember generate command"
+    link: "https://blog.emberjs.com/ember-released-4-3"
+  -
+    deprecation: true
+    title: "Deprecate Bower support"
+    link: "https://blog.emberjs.com/ember-released-4-3"
+---

--- a/source/ember-cli-changes/4.4.md
+++ b/source/ember-cli-changes/4.4.md
@@ -1,0 +1,4 @@
+---
+version: "4.4"
+changes:
+---

--- a/source/ember-cli-changes/4.5.md
+++ b/source/ember-cli-changes/4.5.md
@@ -1,0 +1,12 @@
+---
+version: "4.5"
+changes:
+  -
+    deprecation: true
+    title: "Using the terms whitelist and blacklist build options are deprecated. Please use include and exclude instead. Only the name of the option has changed, and the functionality is unchanged."
+    link: "https://blog.emberjs.com/ember-4-5-released"
+  -
+    deprecation: true
+    title: "Support for ember-cli-jshint is deprecated."
+    link: "https://blog.emberjs.com/ember-4-5-released"
+---

--- a/source/ember-cli-changes/4.6.md
+++ b/source/ember-cli-changes/4.6.md
@@ -1,0 +1,8 @@
+---
+version: "4.6"
+changes:
+  -
+    deprecation: true
+    title: "The vendor-shim blueprint is deprecated. Please use ember-auto-import instead."
+    link: "https://blog.emberjs.com/ember-4-6-released"
+---

--- a/source/ember-cli-changes/4.7.md
+++ b/source/ember-cli-changes/4.7.md
@@ -1,0 +1,4 @@
+---
+version: "4.7"
+changes:
+---

--- a/source/ember-cli-changes/4.8.md
+++ b/source/ember-cli-changes/4.8.md
@@ -1,0 +1,12 @@
+---
+version: "4.8"
+changes:
+  -
+    feature: true
+    title: "Added Node v18 to engines in the app and addon blueprints (removes support for Node v17, which is a breaking change)."
+    link: "https://blog.emberjs.com/ember-4-8-released"
+  -
+    feature: true
+    title: "Updated the app and addon blueprints to use const to avoid unnecessary linting errors."
+    link: "https://blog.emberjs.com/ember-4-8-released"
+---

--- a/source/ember-cli-changes/4.9.md
+++ b/source/ember-cli-changes/4.9.md
@@ -1,0 +1,36 @@
+---
+version: "4.9"
+changes:
+  -
+    feature: true
+    title: "Add ember-source to peerDependencies in addon blueprint."
+    link: "https://blog.emberjs.com/ember-4-9-released"
+  -
+    feature: true
+    title: "Update NPM version constraints to include more recent versions."
+    link: "https://blog.emberjs.com/ember-4-9-released"
+  -
+    feature: true
+    title: "Display info message when running the lint:fix script post blueprint generation."
+    link: "https://blog.emberjs.com/ember-4-9-released"
+  -
+    feature: true
+    title: "Add support for node ES Module syntax addons."
+    link: "https://blog.emberjs.com/ember-4-9-released"
+  -
+    feature: true
+    title: "Add interactive way to create new Ember apps and addons."
+    link: "https://blog.emberjs.com/ember-4-9-released"
+  -
+    feature: true
+    title: "Add support for --typescript flag to app and addon blueprints."
+    link: "https://blog.emberjs.com/ember-4-9-released"
+  -
+    deprecation: true
+    title: "Disable prototype extensions by default in app blueprint."
+    link: "https://blog.emberjs.com/ember-4-9-released"
+  -
+    deprecation: true
+    title: "Drop support for using usePods: true and the --pod flag simultaneously."
+    link: "https://blog.emberjs.com/ember-4-9-released"
+---

--- a/source/ember-data-changes/4.10.md
+++ b/source/ember-data-changes/4.10.md
@@ -1,0 +1,4 @@
+---
+version: '4.10'
+changes:
+---

--- a/source/ember-data-changes/4.11.md
+++ b/source/ember-data-changes/4.11.md
@@ -1,0 +1,4 @@
+---
+version: '4.11'
+changes:
+---

--- a/source/ember-data-changes/4.12.md
+++ b/source/ember-data-changes/4.12.md
@@ -1,0 +1,22 @@
+---
+version: '4.12'
+changes:
+  -
+    feature: true
+    title: "@ember-data/request has its first Stable Release!"
+    link: "https://blog.emberjs.com/ember-released-4-12"    
+  -
+    feature: true
+    title: "Numerous APIs associated with the Cache, Notifications, Identity Management, and Record Lifecycle have new or improved docs"
+    link: "https://blog.emberjs.com/ember-released-4-12"  
+  -
+    feature: true
+    title: "The Notifications Service has Expanded Capabilities"
+    link: "https://blog.emberjs.com/ember-released-4-12"  
+  -
+    feature: true
+    title: "Cache Spec 2.1 implementation ="
+    link: "https://blog.emberjs.com/ember-released-4-12"  
+---
+
+

--- a/source/ember-data-changes/4.3.md
+++ b/source/ember-data-changes/4.3.md
@@ -1,0 +1,4 @@
+---
+version: "4.3"
+changes:
+---

--- a/source/ember-data-changes/4.4.md
+++ b/source/ember-data-changes/4.4.md
@@ -1,0 +1,8 @@
+---
+version: '4.4'
+changes:
+  -
+    deprecation: true
+    title: "Model.save() will return a native Promise instead of a PromiseProxyMixin. To return a Promise, you can set your compatWith to 4.4."
+    link: "https://blog.emberjs.com/ember-released-4-4/"
+---

--- a/source/ember-data-changes/4.5.md
+++ b/source/ember-data-changes/4.5.md
@@ -1,0 +1,36 @@
+---
+version: '4.5'
+changes:
+  -
+    deprecation: true
+    title: "deprecating some internal usage of RSVP.Promise that applications may have become dependent on if their tests are leaky."
+    link: "https://blog.emberjs.com/ember-4-6-released/"
+  -
+    deprecation: true
+    title: "deprecating the type property on snapshots (which would lookup the model class)."
+    link: "https://blog.emberjs.com/ember-4-6-released/"
+  -
+    deprecation: true
+    title: "deprecating store.find, a private method that has been maintained in case users accidentally fell into using ember's hidden autofetch behavior in routes."
+    link: "https://blog.emberjs.com/ember-4-6-released/"
+  -
+    deprecation: true
+    title: "deprecating store.hasRecordForId, as peekRecord is generally more useful and provides the same information (and more)."
+    link: "https://blog.emberjs.com/ember-4-6-released/"
+  -
+    deprecation: true
+    title: "deprecating store.recordWasInvalid, an unused internal api that ember-model-validations appears to be using."
+    link: "https://blog.emberjs.com/ember-4-6-released/"
+  -
+    deprecation: true
+    title: "deprecating passing strings to the schema lookup functions attributesDefinitionFor and relationshipsDefinitionFor, these APIs now expect an object with at least a type property representing the model name."
+    link: "https://blog.emberjs.com/ember-4-6-released/"
+  -
+    deprecation: true
+    title: "deprecating the -json-api fallback adapter, a hidden behavior that provided an adapter if the application failed to define one."
+    link: "https://blog.emberjs.com/ember-4-6-released/"
+  -
+    feature: true
+    title: "Ember Data 4.5 introduced improvements to build size."
+    link: "https://blog.emberjs.com/ember-4-6-released/"    
+---

--- a/source/ember-data-changes/4.6.md
+++ b/source/ember-data-changes/4.6.md
@@ -1,0 +1,4 @@
+---
+version: '4.6'
+changes:
+---

--- a/source/ember-data-changes/4.7.md
+++ b/source/ember-data-changes/4.7.md
@@ -1,0 +1,28 @@
+---
+version: '4.7'
+changes:
+  -
+    deprecation: true
+    title: "Implement helper deprecations  (RFC 742)."
+    link: "https://blog.emberjs.com/ember-released-4-7"
+  -
+    deprecation: true
+    title: "Deprecate Model.reopen/reopenClass and eager static fields lookups (implements RFC 738 and RFC 741)."
+    link: "https://blog.emberjs.com/ember-released-4-7"
+  -
+    deprecation: true
+    title: "Eliminate InternalModel, nearly all private API's have undergone significant change, if your app previously used these APIs the most likely refactor is to use a custom model or a custom cache."
+    link: "https://blog.emberjs.com/ember-released-4-7"
+  -
+    deprecation: true
+    title: "Implement strict relationships (RFC 739)."
+    link: "https://blog.emberjs.com/ember-released-4-7"
+  -
+    feature: true
+    title: "Explicit Polymorphic Relationship Support"
+    link: "https://blog.emberjs.com/ember-released-4-7"    
+  -
+    feature: true
+    title: "The return values of hasMany relationships, peekAll, findAll and query are now proxies to native arrays and as such all native array APIs are now usable. These objects will act fully as if they are native arrays. Restrictions on immutability of the result of peekAll and query still apply (RFC 846)."
+    link: "https://blog.emberjs.com/ember-released-4-7"  
+---

--- a/source/ember-data-changes/4.8.md
+++ b/source/ember-data-changes/4.8.md
@@ -1,0 +1,16 @@
+---
+version: '4.8'
+changes:
+  -
+    feature: true
+    title: "add identifier data to Reference public API"
+    link: "https://github.com/emberjs/data/releases/tag/v4.8.2"    
+  -
+    feature: true
+    title: "@ember-data/tracking primitives to prevent backtracking render errors. These objects will act fully as if they are native arrays. Restrictions on immutability of the result of peekAll and query still apply (RFC 846)."
+    link: "https://github.com/emberjs/data/releases/tag/v4.8.2"  
+  -
+    feature: true
+    title: "enhance debug logging abilities"
+    link: "https://github.com/emberjs/data/releases/tag/v4.8.2"
+---

--- a/source/ember-data-changes/4.9.md
+++ b/source/ember-data-changes/4.9.md
@@ -1,0 +1,4 @@
+---
+version: '4.9'
+changes:
+---

--- a/source/ember-js-changes/4.10.md
+++ b/source/ember-js-changes/4.10.md
@@ -1,0 +1,29 @@
+---
+version: "4.10"
+changes:
+  -
+    feature: true
+    title: "Add new imports for getOwner and setOwner from @ember/owner and introduce new @ember/routing sub-modules"
+    link: "https://blog.emberjs.com/ember-released-4-10"
+  -
+    feature: true
+    title: "Add the Resolver type to preview types"
+    link: "https://blog.emberjs.com/ember-released-4-10"
+  -
+    feature: true
+    title: "resolve services with Owner.lookup"
+    link: "https://blog.emberjs.com/ember-released-4-10"
+  -
+    deprecation: true
+    title: "Deprecations for importing htmlSafe and isHTMLSafe from @ember/string. They have moved to @ember/template"
+    link: "https://blog.emberjs.com/ember-released-4-10"
+  -
+    deprecation: true
+    title: "Deprecate @ember/string when used from ember-source. You should use the @ember/string-addon"
+    link: "https://blog.emberjs.com/ember-released-4-10"
+  -
+    deprecation: true
+    title: "Deprecate @ember/error"
+    link: "https://blog.emberjs.com/ember-released-4-10"
+
+---

--- a/source/ember-js-changes/4.11.md
+++ b/source/ember-js-changes/4.11.md
@@ -1,0 +1,12 @@
+---
+version: "4.11"
+changes:
+  -
+    feature: true
+    title: "Stable TypeScript types for the @ember/owner package (first released in 4.10)"
+    link: "https://blog.emberjs.com/ember-released-4-11"
+  -
+    feature: true
+    title: "Stable TypeScript types for the @ember/error package."
+    link: "https://blog.emberjs.com/ember-released-4-11"
+---

--- a/source/ember-js-changes/4.12.md
+++ b/source/ember-js-changes/4.12.md
@@ -1,0 +1,16 @@
+---
+version: "4.12"
+changes:
+  -
+    feature: true
+    title: "Enable generating Typescript blueprints when isTypeScriptProject is true without additional environment variables per RFC #800."
+    link: "https://blog.emberjs.com/ember-released-4-12"
+  -
+    feature: true
+    title: "Enhance the Typescript blueprint for generated services per RFC #800."
+    link: "https://blog.emberjs.com/ember-released-4-12"
+  -
+    feature: true
+    title: "Generate signature in TypeScript Glimmer Component blueprints per RFC #800."
+    link: "https://blog.emberjs.com/ember-released-4-12"
+---

--- a/source/ember-js-changes/4.3.md
+++ b/source/ember-js-changes/4.3.md
@@ -1,0 +1,20 @@
+---
+version: "4.3"
+changes:
+  -
+    feature: true
+    title: "Better debuggability! When your app is in DEBUG mode, it is now easier to dig into Store, Symbol, and RecordReference"
+    link: "https://blog.emberjs.com/ember-released-4-3"
+  -
+    feature: true
+    title: "Add support for Customizeable test setups"
+    link: "https://blog.emberjs.com/ember-released-4-3"
+  -
+    feature: true
+    title: "The Reference API is now compatible with autotracking"
+    link: "https://blog.emberjs.com/ember-released-4-3"
+  -
+    feature: true
+    title: "`attributesDefinitionFor` and `relationshipsDefinitionFor` have a simpler API"
+    link: "https://blog.emberjs.com/ember-released-4-3"
+---

--- a/source/ember-js-changes/4.4.md
+++ b/source/ember-js-changes/4.4.md
@@ -1,0 +1,20 @@
+---
+version: "4.4"
+changes:
+  -
+    feature: true
+    title: "The {{unique-id}} helper will be included by default in new Ember apps. Developers can use this helper to generate a unique ID string suitable for use as an ID attribute in the DOM."
+    link: "https://blog.emberjs.com/ember-released-4-4"
+  -
+    feature: true
+    title: "When a deprecation has the until field set, it will now be logged with the other information"
+    link: "https://blog.emberjs.com/ember-released-4-4"
+  -
+    feature: true
+    title: "The customization of setupTest* functions is now available. The app and addon blueprints will create a file at tests/helpers/index.js where these functions will be wrapped and exported, creating a local place to edit for each type of test setup. Tests generated using ember generate will import the setup functions from that file."
+    link: "https://blog.emberjs.com/ember-released-4-4"
+  -
+    feature: true
+    title: "`The hasListeners function is now public, so you can call this before calling removeListeners"
+    link: "https://blog.emberjs.com/ember-released-4-4"
+---

--- a/source/ember-js-changes/4.5.md
+++ b/source/ember-js-changes/4.5.md
@@ -1,0 +1,12 @@
+---
+version: "4.5"
+changes:
+  -
+    feature: true
+    title: "Plain function as helpers"
+    link: "https://blog.emberjs.com/ember-4-5-released"
+  -
+    feature: true
+    title: "A new renderSettled test helper"
+    link: "https://blog.emberjs.com/ember-4-5-released"
+---

--- a/source/ember-js-changes/4.6.md
+++ b/source/ember-js-changes/4.6.md
@@ -1,0 +1,4 @@
+---
+version: "4.6"
+changes:
+---

--- a/source/ember-js-changes/4.7.md
+++ b/source/ember-js-changes/4.7.md
@@ -1,0 +1,4 @@
+---
+version: "4.7"
+changes:
+---

--- a/source/ember-js-changes/4.8.md
+++ b/source/ember-js-changes/4.8.md
@@ -1,0 +1,8 @@
+---
+version: "4.8"
+changes:
+  -
+    feature: true
+    title: "an opt-in preview of Ember's official TypeScript types"
+    link: "https://blog.emberjs.com/ember-4-8-released"
+---

--- a/source/ember-js-changes/4.9.md
+++ b/source/ember-js-changes/4.9.md
@@ -1,0 +1,12 @@
+---
+version: "4.9"
+changes:
+  -
+    feature: true
+    title: "upgrades TypeScript dependency to use version 4.8."
+    link: "https://blog.emberjs.com/ember-4-9-released"
+  -
+    feature: true
+    title: "introduces support for testing all supported versions of TypeScript against our types and removes type checking from lint scripts."
+    link: "https://blog.emberjs.com/ember-4-9-released"
+---

--- a/tests/acceptance/changes-test.js
+++ b/tests/acceptance/changes-test.js
@@ -16,8 +16,8 @@ module('Acceptance | changes', function (hooks) {
 
     assert.strictEqual(
       newFeaturesInEmberJS.length,
-      16,
-      'We see 16 new features that occurred in Ember.js since version 3.15'
+      37,
+      'We see 37 new features that occurred in Ember.js since version 3.15'
     );
 
     // Check deprecations in Ember.js
@@ -27,8 +27,8 @@ module('Acceptance | changes', function (hooks) {
 
     assert.strictEqual(
       deprecationsInEmberJS.length,
-      26,
-      'We see 26 deprecations that occurred in Ember.js since version 3.15'
+      29,
+      'We see 29 deprecations that occurred in Ember.js since version 3.15'
     );
 
     // Check new features in Ember Data
@@ -38,8 +38,8 @@ module('Acceptance | changes', function (hooks) {
 
     assert.strictEqual(
       newFeaturesInEmberData.length,
-      1,
-      'We see 1 new feature that occurred in Ember Data since version 3.15'
+      11,
+      'We see 11 new feature that occurred in Ember Data since version 3.15'
     );
 
     // Check deprecations in Ember Data
@@ -49,8 +49,8 @@ module('Acceptance | changes', function (hooks) {
 
     assert.strictEqual(
       deprecationsInEmberData.length,
-      2,
-      'We see 2 deprecations that occurred in Ember Data since version 3.15'
+      14,
+      'We see 14 deprecations that occurred in Ember Data since version 3.15'
     );
 
     // Check new features in Ember CLI
@@ -60,8 +60,8 @@ module('Acceptance | changes', function (hooks) {
 
     assert.strictEqual(
       newFeaturesInEmberCLI.length,
-      30,
-      'We see 30 new features that occurred in Ember CLI since version 3.15'
+      56,
+      'We see 56 new features that occurred in Ember CLI since version 3.15'
     );
 
     // Check deprecations in Ember CLI
@@ -71,8 +71,8 @@ module('Acceptance | changes', function (hooks) {
 
     assert.strictEqual(
       deprecationsInEmberCLI.length,
-      2,
-      'We see 2 deprecations that occurred in Ember CLI since version 3.15'
+      8,
+      'We see 8 deprecations that occurred in Ember CLI since version 3.15'
     );
   });
 


### PR DESCRIPTION
This updates deprecations and features for ember-source ember-data and ember-cli up to 4.12

There may be some missing things for ember-data as the info hasn't been as easy to get,

Also ember-data 4.5 uses blog post 4.6 is show its changes as they didnt have enough people to meet the normal release schedule