### PR TITLE
Add option groups to version select

### DIFF
--- a/app/components/ember-versions-form.hbs
+++ b/app/components/ember-versions-form.hbs
@@ -10,13 +10,17 @@
       id="from-version"
       {{on "input" this.updateFromVersion}}
     >
-      {{#each this.versions as |version|}}
-        <option
-          selected={{eq version this.fromVersion}}
-          value={{version}}
-        >
-          {{version}}
-        </option>
+      {{#each this.groupedVersions as |versionGroup|}}
+        <optgroup label={{concat "v" versionGroup.major ".x"}}>
+          {{#each versionGroup.versions as |version|}}
+            <option
+              selected={{eq version this.fromVersion}}
+              value={{version}}
+            >
+              {{version}}
+            </option>
+          {{/each}}
+        </optgroup>
       {{/each}}
     </select>
   </div>
@@ -29,13 +33,17 @@
       id="to-version"
       {{on "input" this.updateToVersion}}
     >
-      {{#each this.versions as |version|}}
-        <option
-          selected={{eq version this.toVersion}}
-          value={{version}}
-        >
-          {{version}}
-        </option>
+      {{#each this.groupedVersions as |versionGroup|}}
+        <optgroup label={{concat "v" versionGroup.major ".x"}}>
+          {{#each versionGroup.versions as |version|}}
+            <option
+              selected={{eq version this.toVersion}}
+              value={{version}}
+            >
+              {{version}}
+            </option>
+          {{/each}}
+        </optgroup>
       {{/each}}
     </select>
   </div>

--- a/app/components/ember-versions-form.js
+++ b/app/components/ember-versions-form.js
@@ -4,8 +4,21 @@ import { tracked } from '@glimmer/tracking';
 import { VERSIONS } from 'upgrade-guide/utils/ember-versions';
 import { compare } from 'compare-versions';
 
+// Group the versions by major so we can display option groups.
+const GROUPED_VERSIONS = VERSIONS.reduce((acc, version) => {
+  const major = version.split('.')[0];
+  let group = acc.find((g) => g.major === major);
+  if (!group) {
+    group = { major, versions: [] };
+    acc.push(group);
+  }
+  group.versions.push(version);
+  return acc;
+}, []);
+
 export default class EmberVersionsFormComponent extends Component {
   versions = VERSIONS;
+  groupedVersions = GROUPED_VERSIONS;
   @tracked fromVersion = '3.15';
   @tracked toVersion = VERSIONS[VERSIONS.length - 1];
 

--- a/app/utils/ember-versions.js
+++ b/app/utils/ember-versions.js
@@ -1,7 +1,7 @@
 export const VERSIONS = Object.freeze([
+  '0.13',
   '1.0.0-pre',
   '1.0.0-pre.2',
-  '0.13',
   '1.0.0-rc.1',
   '1.0.0-rc.2',
   '1.0.0-rc.3',


### PR DESCRIPTION
This small PR breaks up the long version list by adding `<optgroup>` elements to the `<select>` for both the TO and FROM versions.

Before
<img width="1266" height="1131" alt="before" src="https://github.com/user-attachments/assets/edccf413-d02d-4ef4-92a6-ed6698186707" />

After
<img width="1262" height="874" alt="after" src="https://github.com/user-attachments/assets/76681756-c460-4080-bcff-3238b004f657" />

