### PR TITLE
Get tests running

### DIFF
--- a/app/models/private/-common.js
+++ b/app/models/private/-common.js
@@ -5,10 +5,12 @@ export default class CommonModel extends Model {
   @attr changes;
 
   get features() {
-    return (this.changes || []).filterBy('feature');
+    return (this.changes || []).filter((change) => Boolean(change?.feature));
   }
 
   get deprecations() {
-    return (this.changes || []).filterBy('deprecation');
+    return (this.changes || []).filter((change) =>
+      Boolean(change?.deprecation),
+    );
   }
 }

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,1 +1,22 @@
 /* Ember supports plain CSS out of the box. More info: https://cli.emberjs.com/release/advanced-use/stylesheets/ */
+
+/* 
+This project is using an old version of the styleguide, so these highly-targeted rules are a bridge
+to meet accessibility guidelines until we upgrade to a compliant styleguide.
+*/
+
+footer.es-footer {
+  .footer-help {
+    p {
+      a {
+        text-decoration: underline;
+      }
+    }
+  }
+}
+
+main > section.container > form {
+  button.es-button {
+    background-color: #db3122;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
-    "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\""
+    "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
+    "test:ember": "ember test"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",

--- a/tests/acceptance/changes-test.js
+++ b/tests/acceptance/changes-test.js
@@ -3,6 +3,17 @@ import { click, currentURL, findAll, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 
+// When a new version is added, update these numbers
+const LATEST_DELTAS = {
+  version: '7.0',
+  emberNewFeatures: 50,
+  emberDeprecations: 36,
+  emberDataNewFeatures: 21,
+  emberDataDeprecations: 18,
+  emberCLINewFeatures: 96,
+  emberCLIDeprecations: 14,
+};
+
 module('Acceptance | changes', function (hooks) {
   setupApplicationTest(hooks);
 
@@ -16,8 +27,8 @@ module('Acceptance | changes', function (hooks) {
 
     assert.strictEqual(
       newFeaturesInEmberJS.length,
-      43,
-      'We see 43 new features that occurred in Ember.js since version 3.15',
+      LATEST_DELTAS.emberNewFeatures,
+      `We see ${LATEST_DELTAS.emberNewFeatures} new features that occurred in Ember.js since version 3.15`,
     );
 
     // Check deprecations in Ember.js
@@ -27,8 +38,8 @@ module('Acceptance | changes', function (hooks) {
 
     assert.strictEqual(
       deprecationsInEmberJS.length,
-      33,
-      'We see 33 deprecations that occurred in Ember.js since version 3.15',
+      LATEST_DELTAS.emberDeprecations,
+      `We see ${LATEST_DELTAS.emberDeprecations} deprecations that occurred in Ember.js since version 3.15`,
     );
 
     // Check new features in Ember Data
@@ -38,8 +49,8 @@ module('Acceptance | changes', function (hooks) {
 
     assert.strictEqual(
       newFeaturesInEmberData.length,
-      21,
-      'We see 21 new feature that occurred in Ember Data since version 3.15',
+      LATEST_DELTAS.emberDataNewFeatures,
+      `We see ${LATEST_DELTAS.emberDataNewFeatures} new feature that occurred in Ember Data since version 3.15`,
     );
 
     // Check deprecations in Ember Data
@@ -49,8 +60,8 @@ module('Acceptance | changes', function (hooks) {
 
     assert.strictEqual(
       deprecationsInEmberData.length,
-      18,
-      'We see 18 deprecations that occurred in Ember Data since version 3.15',
+      LATEST_DELTAS.emberDataDeprecations,
+      `We see ${LATEST_DELTAS.emberDataDeprecations} deprecations that occurred in Ember Data since version 3.15`,
     );
 
     // Check new features in Ember CLI
@@ -60,8 +71,8 @@ module('Acceptance | changes', function (hooks) {
 
     assert.strictEqual(
       newFeaturesInEmberCLI.length,
-      74,
-      'We see 74 new features that occurred in Ember CLI since version 3.15',
+      LATEST_DELTAS.emberCLINewFeatures,
+      `We see ${LATEST_DELTAS.emberCLINewFeatures} new features that occurred in Ember CLI since version 3.15`,
     );
 
     // Check deprecations in Ember CLI
@@ -71,8 +82,8 @@ module('Acceptance | changes', function (hooks) {
 
     assert.strictEqual(
       deprecationsInEmberCLI.length,
-      10,
-      'We see 10 deprecations that occurred in Ember CLI since version 3.15',
+      LATEST_DELTAS.emberCLIDeprecations,
+      `We see ${LATEST_DELTAS.emberCLIDeprecations} deprecations that occurred in Ember CLI since version 3.15`,
     );
   });
 


### PR DESCRIPTION
This PR adds a `test:ember` script so the tests are run by devs and CI.

The tests haven't been running in a while, so I also had to make a couple very minor code changes to get them passing.

Whenever a new release is published, somebody has to add the version to this app.  Then, they also need to update the tests in 12 places to reflect the current deltas from the (arbitrary?) version 3.15.  This whole thing should probably be reworked, but this isn't the PR for that. I couldn't resist one small refactor, though. Now, instead of updating the values in 12 places, there's a constant at the top of the test file.

Fixes: #162 