### PR TITLE
Use customizable select for version pickers

### DIFF
--- a/app/components/ember-versions-form.hbs
+++ b/app/components/ember-versions-form.hbs
@@ -1,4 +1,5 @@
 <form
+  class="ember-versions-form"
   data-test-form="Ember Versions"
   {{on "submit" this.submitForm}}
 >
@@ -12,6 +13,7 @@
     >
       {{#each this.groupedVersions as |versionGroup|}}
         <optgroup label={{concat "v" versionGroup.major ".x"}}>
+          <legend>{{versionGroup.major}}.x Versions</legend>
           {{#each versionGroup.versions as |version|}}
             <option
               selected={{eq version this.fromVersion}}
@@ -35,6 +37,7 @@
     >
       {{#each this.groupedVersions as |versionGroup|}}
         <optgroup label={{concat "v" versionGroup.major ".x"}}>
+          <legend>{{versionGroup.major}}.x Versions</legend>
           {{#each versionGroup.versions as |version|}}
             <option
               selected={{eq version this.toVersion}}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,5 +1,7 @@
 /* Ember supports plain CSS out of the box. More info: https://cli.emberjs.com/release/advanced-use/stylesheets/ */
 
+@import url("./ember-versions-form.css");
+
 /* 
 This project is using an old version of the styleguide, so these highly-targeted rules are a bridge
 to meet accessibility guidelines until we upgrade to a compliant styleguide.

--- a/app/styles/ember-versions-form.css
+++ b/app/styles/ember-versions-form.css
@@ -14,6 +14,9 @@
     select::picker(select) {
       appearance: base-select;
       background-color: var(--color-gray-100);
+      margin-right: var(--spacing-6);
+      margin-bottom: var(--spacing-1);
+      border-radius: var(--radius);
     }
 
     select::picker-icon {

--- a/app/styles/ember-versions-form.css
+++ b/app/styles/ember-versions-form.css
@@ -1,0 +1,69 @@
+.ember-versions-form {
+  /* Fallback styling for older browsers */
+  select {
+    appearance: auto;
+  }
+
+  /* Progressive enhancement for modern browsers */
+  @supports (appearance: base-select) {
+    select {
+      appearance: base-select;
+    }
+
+    /* stylelint-disable selector-pseudo-element-no-unknown */
+    select::picker(select) {
+      appearance: base-select;
+      background-color: var(--color-gray-100);
+    }
+
+    select::picker-icon {
+      transition: 150ms ease;
+    }
+
+    /* stylelint-disable selector-pseudo-class-no-unknown */
+    select:open::picker-icon {
+      rotate: 180deg;
+    }
+
+    select optgroup {
+      display: flex;
+      flex-flow: row wrap;
+      gap: 0.5rem;
+      padding: 0.5rem;
+    }
+
+    select optgroup legend {
+      width: 100%;
+    }
+
+    select option {
+      background-color: var(--color-button-secondary-bg);
+      color: var(--color-button-secondary-text);
+
+      &:hover {
+        background-color: var(--color-button-secondary-bg-hover);
+        color: var(--color-button-secondary-text-hover);
+      }
+
+      display: inline-block;
+      padding: 0.25rem;
+      border-radius: 0.25rem;
+      align-content: center;
+      cursor: pointer;
+    }
+
+    select option::checkmark {
+      display: none;
+    }
+
+    select option:checked {
+      background-color: var(--color-button-bg);
+      color: var(--color-white);
+    }
+
+    select option:checked::checkmark {
+      display: inline-block;
+      color: var(--color-button-text);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds styles to the two version pickers.

It use the new(ish) built-in support for customizable select elements.  This is available in Chrome 135 and Safari 27.  The beauty of how customizable select works is that it literally uses the stock `<select>` element, so it works perfectly in browsers that don't yet support the standard (aka, Firefox).  This means it is fully accessible and requires no markup hacks, positioning logic, or focus handling.

The problem being addressed is that the list of versions goes on and on and on. I updated it so the version options are displayed horizontally within their option group.  The options and option groups are minimally styled, leaving everything else to the browser.

Before:

<img width="1129" height="1280" alt="select-before" src="https://github.com/user-attachments/assets/305a0332-4e3d-49ab-bd66-a826ec17f838" />


After:

<img width="1104" height="1027" alt="select-after" src="https://github.com/user-attachments/assets/84026574-9269-42df-990e-a27dc7afb77d" />




See:
- [MDN Web Docs on Customizable select elements](https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select)
- [Apple's WWDC26 presentation on this stuff](https://www.youtube.com/watch?v=ACsHgWwP9Io)
- [Google developer docs](https://developer.chrome.com/blog/a-customizable-select)